### PR TITLE
Add new `show` command to `envman` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ $ ./uninstall.sh
 
 * `envman create <name>` - Create and save a file called `<name>.env`, based on the `.env` file in the current directory
 * `envman load <name>` -  Load the file `<name>.env` into the `.env` file in the current directory
+* `envman show <name>` - Print out the contents of the file `<name>.env`
 
 ## Data Storage
 

--- a/envman.py
+++ b/envman.py
@@ -9,7 +9,7 @@ ENVS_PATH = os.path.expanduser('~/envs')
 
 def main():
     if len(sys.argv) <= 1:
-        print('Usage: envman [create <name> | load <name>]')
+        print('Usage: envman [create <name> | load <name> | show <name>]')
         sys.exit()
 
     if sys.argv[1] == 'create':
@@ -42,8 +42,21 @@ def main():
                 dest.write(src.read())
                 print('Loaded .env from ~/envs/{}.env'.format(name))
 
+    elif sys.argv[1] == 'show':
+        if len(sys.argv) < 3:
+            print('Error: Please specify a name for the .env file to show')
+
+        name = sys.argv[2]
+        if not os.path.exists('{}/{}.env'.format(ENVS_PATH, name)):
+            print('Error: Could not find ~/envs/{}.env'.format(name))
+            sys.exit()
+
+        with open('{}/{}'.format(ENVS_PATH, name), 'r') as src:
+            out = src.read()
+            print(out)
+
     else:
-        print('Usage: envman [create <name> | load <name>]')
+        print('Usage: envman [create <name> | load <name> | show <name>]')
         sys.exit()
 
 if __name__ == '__main__':

--- a/envman.py
+++ b/envman.py
@@ -51,7 +51,7 @@ def main():
             print('Error: Could not find ~/envs/{}.env'.format(name))
             sys.exit()
 
-        with open('{}/{}'.format(ENVS_PATH, name), 'r') as src:
+        with open('{}/{}.env'.format(ENVS_PATH, name), 'r') as src:
             out = src.read()
             print(out)
 


### PR DESCRIPTION
This PR is intended to add a new `show` command that prints out the contents of a saved `.env` file, without needed to overwrite any files.

Closes #1 